### PR TITLE
Use DnnModel as optional input rather than ImageOp

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This adds support for running the 2D version of StarDist nucleus detection devel
 
 It is intended for the (at the time of writing) not-yet-released QuPath v0.3, and remains in a not-quite-complete state.
 
+> **Note:** The implementation has changed from QuPath v0.2.
+> Nucleus classifications are now supported, but tile padding is not.
+> See the documentation for more details.
+
 ## Installing
 
 To install the StarDist extension, download the latest `qupath-extension-stardist-[version].jar` file and drag it onto QuPath when it is running.


### PR DESCRIPTION
This has one major advantage, and one (I think minor) disadvantage:
- Model output can be either a single merged tensor (as with StarDist-ImageJ) or the 'default' 2 or 3 tensor output at half resolution, depending upon whether classifications are provided or not
- Padding is no longer supported; tile boundary artifacts may occur (although StarDist seems good at handling these)