### PR TITLE
Avoid processing tiles outside of any ROI mask

### DIFF
--- a/src/main/java/qupath/ext/stardist/StarDist2D.java
+++ b/src/main/java/qupath/ext/stardist/StarDist2D.java
@@ -801,6 +801,7 @@ public class StarDist2D {
 		else
 			log("Detecting nuclei");
 		var nuclei = tiles.parallelStream()
+				.filter(t -> mask == null || mask.intersects(GeometryTools.createRectangle(t.getImageX(), t.getImageY(), t.getImageWidth(), t.getImageHeight())))
 				.flatMap(t -> detectObjectsForTile(op, dnn, imageData, t.getRegionRequest(), tiles.size() > 1, mask).stream())
 				.collect(Collectors.toList());
 		


### PR DESCRIPTION
Previously, the bounding box was used - resulting in many unnecessary tiles being processed (sometimes).