### PR TITLE
Bug fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   // To create a shadow/fat jar, including dependencies
   id 'com.github.johnrengelman.shadow' version '7.0.0'
   // To manage included native libraries
-  id 'org.bytedeco.gradle-javacpp-platform' version '1.5.6'
+  id 'org.bytedeco.gradle-javacpp-platform' version '1.5.7'
 }
 
 repositories {
@@ -26,7 +26,7 @@ ext.moduleName = 'qupath.extension.stardist'
 
 description = 'QuPath extension to use StarDist'
 
-version = "0.3.0"
+version = "0.3.1-SNAPSHOT"
 
 dependencies {
     def qupathVersion = "0.3.0" // For now

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/qupath/ext/stardist/StarDist2D.java
+++ b/src/main/java/qupath/ext/stardist/StarDist2D.java
@@ -537,7 +537,7 @@ public class StarDist2D {
 		 * @return this builder
 		 */
 		public Builder inputScale(double... values) {
-			this.ops.add(ImageOps.Core.subtract(values));
+			this.ops.add(ImageOps.Core.multiply(values));
 			return this;
 		}
 		

--- a/src/main/java/qupath/ext/stardist/StarDistExtension.java
+++ b/src/main/java/qupath/ext/stardist/StarDistExtension.java
@@ -51,7 +51,7 @@ public class StarDistExtension implements QuPathExtension, GitHubProject {
 	
 	@Override
 	public Version getQuPathVersion() {
-		return Version.parse("0.3.0-rc2");
+		return Version.parse("0.3.0");
 	}
 
 	@Override


### PR DESCRIPTION
Several fixes
* https://github.com/qupath/qupath-extension-stardist/issues/17
* https://github.com/qupath/qupath-extension-stardist/issues/11 - simple workaround, requires calling `StarDist2D.close()`
* Reduce some occurrences of `TopologyException`

When `TopologyException` does still strike, adding
```
org.locationtech.jts.geom.GeometryOverlay.isOverlayNG = true
```
may be a quick scripting hack to overcome it, see https://forum.image.sc/t/stardist-error-message-topologyexception/67708/7