### PR TITLE
Fix z-stack bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext.moduleName = 'qupath.extension.stardist'
 
 description = 'QuPath extension to use StarDist'
 
-version = "0.3.1"
+version = "0.3.2"
 
 dependencies {
     def qupathVersion = "0.3.0" // For now

--- a/src/main/java/qupath/ext/stardist/StarDist2D.java
+++ b/src/main/java/qupath/ext/stardist/StarDist2D.java
@@ -102,7 +102,7 @@ import qupath.opencv.ops.ImageOps;
  */
 public class StarDist2D implements AutoCloseable {
 
-	private final static Logger logger = LoggerFactory.getLogger(StarDist2D.class);
+	private static final Logger logger = LoggerFactory.getLogger(StarDist2D.class);
 	
 	private static int defaultTileSize = 1024;
 	
@@ -737,7 +737,7 @@ public class StarDist2D implements AutoCloseable {
 	 * @param fireUpdate if true, a hierarchy update will be fired on completion
 	 */
 	private void detectObjectsImpl(ImageData<BufferedImage> imageData, PathObject parent, boolean fireUpdate) {
-		Objects.nonNull(parent);
+		Objects.requireNonNull(parent);
 		// Lock early, so the user doesn't make modifications
 		boolean wasLocked = parent.isLocked();
 		parent.setLocked(true);
@@ -1083,7 +1083,7 @@ public class StarDist2D implements AutoCloseable {
 			int y1 = (int)Math.max(0, Math.round(request.getY() - downsample * pad));
 			int x2 = (int)Math.min(server.getWidth(), Math.round(request.getMaxX() + downsample * pad));
 			int y2 = (int)Math.min(server.getHeight(), Math.round(request.getMaxY() + downsample * pad));
-			requestPadded = RegionRequest.createInstance(server.getPath(), downsample, x1, y1, x2-x1, y2-y1);
+			requestPadded = RegionRequest.createInstance(server.getPath(), downsample, x1, y1, x2-x1, y2-y1, request.getZ(), request.getT());
 		}
 		
 //		// Hack to visualize the tiles that are computed (for debugging)


### PR DESCRIPTION
Fixes issue where non-zero padding could result in the first plane of a stack always being used for detection, rather than the correct one.

See https://forum.image.sc/t/cell-detection-with-stardist-on-2d-stack-images/73264/5