### PR TITLE
Minor fixes

### DIFF
--- a/src/main/java/qupath/ext/stardist/StarDist2D.java
+++ b/src/main/java/qupath/ext/stardist/StarDist2D.java
@@ -67,6 +67,7 @@ import qupath.lib.analysis.features.ObjectMeasurements;
 import qupath.lib.analysis.features.ObjectMeasurements.Compartments;
 import qupath.lib.analysis.features.ObjectMeasurements.Measurements;
 import qupath.lib.common.GeneralTools;
+import qupath.lib.common.LogTools;
 import qupath.lib.gui.UserDirectoryManager;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ColorTransforms;
@@ -189,9 +190,22 @@ public class StarDist2D implements AutoCloseable {
 		 * @return this builder
 		 */
 		public Builder preprocess(ImageOp... ops) {
-			for (var op : ops)
-				this.preprocessing.add(op);
+            this.preprocessing.addAll(Arrays.asList(ops));
 			return this;
+		}
+
+		/**
+		 * Delegate to {@link #preprocessGlobal(TileOpCreator)}.
+		 * @param global
+		 * @return
+		 * @deprecated since v0.6.0
+		 */
+		@Deprecated
+		public Builder preprocess(TileOpCreator global) {
+			// See https://github.com/qupath/qupath-extension-stardist/issues/20
+			LogTools.warnOnce(logger,
+					"The preprocess(TileOpCreator) method is deprecated; use preprocessGlobal(TileOpCreator) instead");
+			return preprocessGlobal(global);
 		}
 		
 		/**
@@ -207,7 +221,7 @@ public class StarDist2D implements AutoCloseable {
 		 * @param global preprocessing operation
 		 * @return this builder
 		 */
-		public Builder preprocess(TileOpCreator global) {
+		public Builder preprocessGlobal(TileOpCreator global) {
 			this.globalPreprocessing = global;
 			return this;
 		}

--- a/src/main/resources/scripts/StarDistDeconvolved.groovy
+++ b/src/main/resources/scripts/StarDistDeconvolved.groovy
@@ -16,6 +16,7 @@
 
 import qupath.ext.stardist.StarDist2D
 import qupath.lib.scripting.QP
+import qupath.opencv.ops.ImageOps
 
 // IMPORTANT! Replace this with the path to your StarDist model
 // that takes a single channel as input (e.g. dsb2018_heavy_augment.pb)
@@ -24,14 +25,14 @@ import qupath.lib.scripting.QP
 def modelPath = "/path/to/model.pb"
 
 // Get current image - assumed to have color deconvolution stains set
-var imageData = getCurrentImageData()
+var imageData = QP.getCurrentImageData()
 var stains = imageData.getColorDeconvolutionStains()
 
 // Customize how the StarDist detection should be applied
 // Here some reasonable default options are specified
 def stardist = StarDist2D
     .builder(modelPath)
-    .preprocess( // Extra preprocessing steps, applied sequentially
+    .preprocess( // Extra preprocessing steps, applied sequentially (per-tile)
         ImageOps.Channels.deconvolve(stains), // Color deconvolution
         ImageOps.Channels.extract(0),         // Extract the first stain (indexing starts at 0)
         ImageOps.Filters.median(2)           // Apply a small median filter (optional!)

--- a/src/main/resources/scripts/StarDistTemplate.groovy
+++ b/src/main/resources/scripts/StarDistTemplate.groovy
@@ -24,7 +24,7 @@ def modelPath = "/path/to/model.pb"
 // read the descriptions & remove the lines you don't want
 def stardist = StarDist2D
     .builder(modelPath)
-    .preprocess(                 // Apply normalization, calculating values across the whole image
+    .preprocessGlobal(                 // Apply normalization, calculating values across the whole image
         StarDist2D.imageNormalizationBuilder()
             .maxDimension(4096)    // Figure out how much to downsample large images to make sure the width & height are <= this value
 //          .downsample(1)         // Optional alternative to maxDimension to use the full-resolution image for normalization


### PR DESCRIPTION
Also follow @lacan's suggestion at https://github.com/qupath/qupath-extension-stardist/issues/20 to rename `preprocess` to `preprocessGlobal`

This also includes a workaround for an important Java 21 (specifically) bug that broke the behavior when specifying the number of threads. This seems related to https://bugs.openjdk.org/browse/JDK-8336883 